### PR TITLE
Support for migrated coursePages

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,11 @@ input: meta_data.json
 output: quickbar.json
 
 the final output, available at https://serlo.github.io/quickbar-updater/quickbar.json
+
+### yarn 4-sitemap
+
+input: meta_data.json
+
+output: sitemap.json
+
+output the sitemap (seo) as well. Available at https://serlo.github.io/quickbar-updater/sitemap.json

--- a/src/1-fetch.ts
+++ b/src/1-fetch.ts
@@ -4,17 +4,15 @@ import { Readable } from 'node:stream'
 
 const saEndpoint =
   'https://simpleanalytics.com/api/export/visits?hostname=de.serlo.org'
+  const DAY = 24 * 60 * 60 * 1000;
 
 async function run() {
-  const currentTime = Date.now()
-  const endTime = currentTime - 24 * 60 * 60 * 1000
-  const startTime = currentTime - 21 * 24 * 60 * 60 * 1000
+  const currentTime = Date.now();
+  const endTime = timestampToDate(currentTime - DAY);
+  const startTime = timestampToDate(currentTime - 21 * DAY);
+  const timeRange = `&start=${startTime}&end=${endTime}`;
 
-  const timeRange = `&start=${timestampToDate(startTime)}&end=${timestampToDate(
-    endTime
-  )}`
-
-  console.log('start fetching stats for time range', timeRange)
+  console.log(`Start fetching stats from: ${startTime} to ${endTime}`);
 
   const resPW = await fetch(saEndpoint + timeRange, {
     headers: {

--- a/src/2-extract.ts
+++ b/src/2-extract.ts
@@ -26,7 +26,10 @@ const extractIdFromPath = (path) => {
   // Parse the ID from regex match groups
   if (match && match.groups?.id) {
     const id = parseInt(match.groups.id);
-    if (!isNaN(id)) return id;
+    if(id){
+      return match.groups.coursePageId ? `${id}#${match.groups.coursePageId.substring(1)}` : id;
+    }
+    
   }
 
   // Attempt to resolve ID using the resolver mapping

--- a/src/2-extract.ts
+++ b/src/2-extract.ts
@@ -26,10 +26,10 @@ const extractIdFromPath = (path) => {
   // Parse the ID from regex match groups
   if (match && match.groups?.id) {
     const id = parseInt(match.groups.id);
-    if(id){
-      return match.groups.coursePageId ? `${id}#${match.groups.coursePageId.substring(1)}` : id;
-    }
-    
+    const coursePageId = match.groups.coursePageId?.substring(1);
+
+    if(coursePageId) return `${id}#${coursePageId}`
+    return id
   }
 
   // Attempt to resolve ID using the resolver mapping

--- a/src/2-extract.ts
+++ b/src/2-extract.ts
@@ -17,12 +17,16 @@ const extractIdFromPath = (path) => {
   // Remove protocol and domain
   const cleanedPath = path.replace(/^https?:\/\/de.serlo.org/, '');
   // Original regular expression for matching ID patterns in the path
-  const reg = /^(?:(?:\/[^\/]+)?\/([\d]+)\/[^\/]+|\/([\d]+)|\/taxonomy\/term\/get\/([\d]+))$/;
-  const match = reg.exec(cleanedPath);
+  const reg =
+    /^\/(?<subject>[\w-]+\/)?(?<id>\d+)(?<coursePageId>\/[0-9a-f]+)?\/(?<title>[^/]*)$/;
+
+  const simpleReg = /^\/(?<id>\d+)$/;
+  const match = reg.exec(cleanedPath) ?? simpleReg.exec(cleanedPath);
 
   // Parse the ID from regex match groups
-  if (match) {
-    return parseInt(match[1] || match[2] || match[3], 10);
+  if (match && match.groups?.id) {
+    const id = parseInt(match.groups.id);
+    if (!isNaN(id)) return id;
   }
 
   // Attempt to resolve ID using the resolver mapping

--- a/src/2-extract.ts
+++ b/src/2-extract.ts
@@ -18,7 +18,7 @@ const extractIdFromPath = (path) => {
   const cleanedPath = path.replace(/^https?:\/\/de.serlo.org/, '');
   // Original regular expression for matching ID patterns in the path
   const reg =
-    /^\/(?<subject>[\w-]+\/)?(?<id>\d+)(?<coursePageId>\/[0-9a-f]+)?\/(?<title>[^/]*)$/;
+    /^\/(?<subject>[^/]+\/)?(?<id>\d+)(?<coursePageId>\/[0-9a-f]+)?\/(?<title>[^/]*)$/;
 
   const simpleReg = /^\/(?<id>\d+)$/;
   const match = reg.exec(cleanedPath) ?? simpleReg.exec(cleanedPath);
@@ -28,8 +28,8 @@ const extractIdFromPath = (path) => {
     const id = parseInt(match.groups.id);
     const coursePageId = match.groups.coursePageId?.substring(1);
 
-    if(coursePageId) return `${id}#${coursePageId}`
-    return id
+    if (coursePageId) return `${id}#${coursePageId}`;
+    return id;
   }
 
   // Attempt to resolve ID using the resolver mapping

--- a/src/3-metadata.ts
+++ b/src/3-metadata.ts
@@ -44,7 +44,7 @@ async function run() {
     const isInQuicklinks = quicklinkIds.has(entry.id)
     const hasValidType =
       !entry.meta ||
-      ['Page', 'CoursePage', 'TaxonomyTerm', 'Article'].includes(
+      ['Page', 'TaxonomyTerm', 'Article', 'Course'].includes(
         entry.meta?.uuid?.__typename,
       )
 
@@ -62,7 +62,11 @@ async function run() {
     const entry = toFetch[i]
     try {
       console.log(`Fetching ${entry.id} (${(i / numberOfEntries) * 100}%)`)
-      const data = await request(endpoint, buildQuery(entry.id))
+
+      // remove courseId
+      const id = entry.id.split('#')[0]
+
+      const data = await request(endpoint, buildQuery(id))
       entry.meta = data
       entry.time = Date.now()
       if (!isFastMode) {
@@ -95,53 +99,33 @@ function buildQuery(id) {
     uuid (id: ${id}) {
       __typename
       alias
+      title
+      trashed
 
-      ... on Page {
-        trashed
-        currentRevision {
-          title
-          date
-        }
-      }
-  
-      ... on CoursePage {
-        trashed
-        currentRevision {
-          title
-          date
-        }
-        course {
-          currentRevision {
-            title
-            date
-          }
-          taxonomyTerms {
-            nodes {
-              ...pathToRoot
-            }
-          }
-        }
-      }
-      
-      ... on Article {
-        trashed
-        currentRevision {
-          title
-          date
-        }
+      ... on AbstractTaxonomyTermChild {
         taxonomyTerms {
           nodes {
             ...pathToRoot
           }
         }
       }
-  
+
+      ... on AbstractEntity {
+        currentRevision {
+          date
+        }
+      }
+
+      ... on Page {
+        currentRevision {
+          date
+        }
+      }
+
       ... on TaxonomyTerm {
-        name
-        trashed
-  
         ...pathToRoot
       }
+
     }
   }
   

--- a/src/3-metadata.ts
+++ b/src/3-metadata.ts
@@ -63,7 +63,7 @@ async function run() {
     try {
       console.log(`Fetching ${entry.id} (${(i / numberOfEntries) * 100}%)`)
 
-      // remove courseId
+      // remove coursePageId
       const id = entry.id.split('#')[0]
 
       const data = await request(endpoint, buildQuery(id))
@@ -113,6 +113,12 @@ function buildQuery(id) {
       ... on AbstractEntity {
         currentRevision {
           date
+        }
+      }
+
+      ... on Course {
+        currentRevision {
+          content
         }
       }
 

--- a/src/4-process.ts
+++ b/src/4-process.ts
@@ -59,37 +59,22 @@ export function createQuickBarItems() {
     const uuid = entry.meta.uuid
     // console.log(entry.id, uuid.__typename, JSON.stringify(entry));
     let path = []
-    let title = uuid.currentRevision
-      ? uuid.currentRevision.title.trim()
-      : uuid.name
-      ? uuid.name.trim()
-      : ''
+    let title = uuid.title?.trim() ?? ''
+
+    // maybe special title for course pages?
 
     // Path construction based on type
     if (uuid.__typename === 'TaxonomyTerm') {
       path = constructPath(uuid)
-    } else if (['Article', 'CoursePage'].includes(uuid.__typename)) {
-      if (uuid.__typename === 'Article' && !uuid.taxonomyTerms) path = []
-      else if (uuid.__typename === 'CoursePage' && !uuid.course.taxonomyTerms)
-        path = []
+    }
+    
+    if(['Article', 'Course'].includes(uuid.__typename)) {
+      if(!uuid.taxonomyTerms) path = []
       else {
-        const nodes =
-          uuid.__typename === 'CoursePage'
-            ? uuid.course.taxonomyTerms.nodes
-            : uuid.taxonomyTerms.nodes
+        const nodes = uuid.taxonomyTerms.nodes
         const nodeToBuild = findShortestNodeTree(nodes)
         path = constructPath(nodeToBuild)
       }
-    }
-
-    // Special handling for CoursePage titles
-    if (
-      uuid.__typename === 'CoursePage' &&
-      uuid.course &&
-      uuid.course.currentRevision
-    ) {
-      const courseTitle = uuid.course.currentRevision.title.trim()
-      path.push(courseTitle)
     }
 
     const root = path[0] || ''

--- a/src/5-sitemap.ts
+++ b/src/5-sitemap.ts
@@ -25,7 +25,7 @@ export function createSitemapItems() {
       const coursePageId = entry.id.split('#')[1]
       const content = parseDocumentString(entry.meta.uuid.currentRevision?.content) as CourseDocument
 
-      const pages = content.state.pages
+      const pages = content?.state?.pages
       if (!pages || !pages.length) return accumulator
 
       const pageIndex = Math.max(

--- a/src/5-sitemap.ts
+++ b/src/5-sitemap.ts
@@ -15,8 +15,15 @@ export function createSitemapItems() {
 
     const lastMod = entry.meta.uuid.currentRevision?.date?.split('T')[0]
 
+    let url = alias
+
+    if(entry.meta.uuid.__typename === 'Course' && entry.id.includes('#')){
+      // title should be the course title here, but fetching the courses content only for that is a lot of data
+      url = buildCoursePageUrl(alias, entry.id.split('#')[1], entry.meta.uuid.title)
+    }
+
     const item = {
-      url: alias,
+      url,
       lastMod
     }
 
@@ -40,3 +47,41 @@ export function createSitemapItems() {
 }
 
 createSitemapItems()
+
+
+
+
+// copied from frontend
+export function buildCoursePageUrl(
+  courseAlias: string,
+  coursePageId: string,
+  title: string
+) {
+  const aliasParts = courseAlias.split('/')
+  if (aliasParts.length !== 4) {
+    throw new Error('Invalid course alias')
+  }
+  const base = aliasParts.slice(0, -1).join('/')
+  return `${base}/${coursePageId.split('-')[0]}/${toSlug(title)}`
+}
+
+// Copied from https://github.com/serlo/api.serlo.org/blob/ce94045b513e59da1ddd191b498fe01f6ff6aa0a/packages/server/src/schema/uuid/abstract-uuid/resolvers.ts#L685-L703
+function toSlug(title: string) {
+  return title
+    .toLowerCase()
+    .replace(/ä/g, 'ae')
+    .replace(/ö/g, 'oe')
+    .replace(/ü/g, 'ue')
+    .replace(/ß/g, 'ss')
+    .replace(/á/g, 'a')
+    .replace(/é/g, 'e')
+    .replace(/í/g, 'i')
+    .replace(/ó/g, 'o')
+    .replace(/ú/g, 'u')
+    .replace(/ñ/g, 'n')
+    .replace(/ /g, '-') // replace spaces with hyphens
+    .replace(/[^\w-]+/g, '') // remove all non-word chars including _
+    .replace(/--+/g, '-') // replace multiple hyphens
+    .replace(/^-+/, '') // trim starting hyphen
+    .replace(/-+$/, '') // trim end hyphen
+}


### PR DESCRIPTION
for https://github.com/serlo/quickbar-updater/issues/8

Quite a bit harder than I hoped -_-
**for quickbar:**
since the result is just an `id`-string this now returns `{courseId}#{coursePageId}` that we then can handle in the frontend somehow. this could be an okay workaround without increasing the json size by adding aliases.

**for the sitemap:**
currently the resulting url is `/{subject}/{courseId}/{coursePageId}/{courseTitle}` so pretty close but since this should definitely match the canonical url we would need to fetch the course-content.
Differences to canonical urls: first coursePage url equals course-alias (`/{subject}/{courseId}/{courseTitle}`) and for all other aliases we need the coursePage title.

**regex changes**
 seems to work fine
(values before coursePage migration)
![image](https://github.com/serlo/quickbar-updater/assets/1258870/ce2916b2-92a5-4264-a526-6fef479a555e)


